### PR TITLE
Shorten Enigma by Separating Encrypt/Decrypt into Modules

### DIFF
--- a/lib/encryptable.rb
+++ b/lib/encryptable.rb
@@ -34,6 +34,40 @@ module Encryptable
     encodings
   end
 
+  # :nocov:
+  def create_shifts(raw_key, date_string)
+    raise NotImplementedError
+  end
+
+  def parse_keys(raw_key)
+    raise NotImplementedError
+  end
+
+  def parse_offsets(date_string)
+    raise NotImplementedError
+  end
+
+  def character_set
+    raise NotImplementedError
+  end
+
+  def generate_key
+    raise NotImplementedError
+  end
+
+  def calculate_raw_offset(date_string)
+    raise NotImplementedError
+  end
+
+  def date_string_for(date)
+    raise NotImplementedError
+  end
+
+  def next_after(last_shift)
+    raise NotImplementedError
+  end
+  # :nocov:
+
   private
 
   def encodings_for(orig_index, shift_rules)

--- a/test/encryptable_test.rb
+++ b/test/encryptable_test.rb
@@ -120,4 +120,17 @@ class EncryptableTest < Minitest::Test
     assert_equal 'keder ohulw', @enigma.do_encrypt('hello world', shift_rules)
     assert_equal 'dlxqclxy', @enigma.do_encrypt('alex lee', shift_rules)
   end
+
+  # def test_assumed_containing_class_methods
+  #   assert_raises NotImplementedError do
+  #     @enigma.create_shifts(nil, nil)
+  #     @enigma.parse_keys(nil)
+  #     @enigma.parse_offsets(nil)
+  #     @enigma.character_set
+  #     @enigma.generate_key
+  #     @enigma.calculate_raw_offset(nil)
+  #     @enigma.date_string_for(nil)
+  #     @enigma.next_after(nil)
+  #   end
+  # end
 end


### PR DESCRIPTION
This leaves SimpleCov claiming only 95% coverage, but I believe this is a false negative because SimpleCov doesn't see code in the modules which is referencing methods in Enigma.